### PR TITLE
Gemmer .csv som utf-8 istedet for ansi.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,6 @@ Vasker adresser fra en csv fil. Scriptet itererer igennem en csv fil, tilføjer 
 
 Scriptet henter en rigtigt stavet adresse og UTM koordinater. Den henter også informationer omkring, hvor nøjagtigt den rigtig stavede adresse er.
 Se mere i dokumentationen til Datavask API'et. http://dawa.aws.dk/adressedok#datavask
+
+# Note
+Brug i stedet min c# version

--- a/adressevasker.py
+++ b/adressevasker.py
@@ -14,7 +14,7 @@ print('Gået i gang!')
 
 #Åbner csv filen, der indeholder de adresser, der skal vaskes
 with open(inputFilePath, 'r') as csvFile:
-	with open(outputFilePath, 'w') as csvOutput:
+	with open(outputFilePath, 'w', encoding='utf-8') as csvOutput:
 		csvOutputWriter = csv.writer(csvOutput, lineterminator='\n')
 		csvFileReader = csv.reader(csvFile, delimiter=';') #Her skal man være opmærksom på, hvilken delimiter filen bruger. De mest almindelige er et komma eller en semikolon
 


### PR DESCRIPTION
output filen kunne ikke vise æ,ø,å pga. ansi output format. dette er fixet nu